### PR TITLE
Remove dangling coveralls-next reference in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@babel/core": "^7.23.2",
         "@babel/preset-env": "^7.23.2",
         "@stylistic/eslint-plugin": "^5.10.0",
-        "coveralls-next": "^6.0.1",
         "eslint": "^10.0.3",
         "jest": "^29.7.0",
         "parcel": "^2.10.2"
@@ -5433,53 +5432,6 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/coveralls-next": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/coveralls-next/-/coveralls-next-6.0.2.tgz",
-      "integrity": "sha512-RzaxMFLKyk8p6Rmv4hfNPpLOV16IpraguQGr+BzpPoQUJSFY2ISNPzlsPhq0ogUrz8dAR3P+379ECMjhNqPVWg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "js-yaml": "4.2.0",
-        "lcov-parse": "1.0.0"
-      },
-      "bin": {
-        "coveralls": "bin/coveralls.js"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/coveralls-next/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/coveralls-next/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -7139,16 +7091,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/lcov-parse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-      "integrity": "sha512-aprLII/vPzuQvYZnDRU78Fns9I2Ag3gi4Ipga/hxnVMCZC8DnR2nI7XBqrPoywGfxqIx/DgarGvDJZAD3YBTgQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "bin": {
-        "lcov-parse": "bin/cli.js"
       }
     },
     "node_modules/leven": {


### PR DESCRIPTION
## Description
There's still a dangling coveralls-next reference in package-lock.json due to the wrong command being run when removing it in #32.

## Related Issues
None

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [X] 🧹 Chore / Refactor (code cleanup, npm package updates, linting)
