### PR TITLE
Use persist-credentials: false for actions/checkout

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
@@ -45,6 +47,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Use Node.js 22.x
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           ref: gh-pages
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Merge main into gh-pages
         run: |

--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           ref: gh-pages
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true # required for the `git push` step below
 
       - name: Merge main into gh-pages
         run: |


### PR DESCRIPTION
## Description
By default, using [actions/checkout](https://github.com/actions/checkout) causes a credential to be persisted on disk. Versions below v6.0.0 store the credential directly in the checked-out repo's .git/config, while v6.0.0 and later store it under $RUNNER_TEMP.

Subsequent steps may accidentally publicly persist the credential, e.g. by including it in a publicly accessible artifact via [actions/upload-artifact](https://github.com/actions/upload-artifact).

However, even without this, persisting the credential on disk is non-ideal unless actually needed.

Unless needed for git operations, [actions/checkout](https://github.com/actions/checkout) should be used with persist-credentials: false.

- [Issue on Qlty](https://qlty.sh/gh/mvanderkamp/projects/canvas-sequencer/issues/zizmor/zizmor/artipacked)

## Related Issues
Fixes #39 

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [X] 🧹 Chore / Refactor (code cleanup, npm package updates, linting)
